### PR TITLE
Remove startup parameter from JOB command

### DIFF
--- a/util/_ZJOB.m
+++ b/util/_ZJOB.m
@@ -163,7 +163,7 @@ START	;Private;
 	I $G(%zparams)["ERROR=" S %zjoberr=$P($P(%zparams,"ERROR=",2),"/",1)
 	;
 	; Build parameter list
-	S %zpar="(STA="""_%zjobf1_""":ERROR="""_%zjoberr
+	S %zpar="(ERROR="""_%zjoberr
 	S %zpar=%zpar_""":OUTPUT="""_%zjobout_""""
 	;
 	; Under the GT.M implementation on Unix, process name has no value


### PR DESCRIPTION
The _ZJOB routine adds a startup parameter to the JOB command that
executes gtmenv to set basic environment variables and basic environment
sanity, however YottaDB/GT.M doesn't support setting environment
variables for the JOBed process on Linux, so the startup parameter
is essentially useless. The _ZJOB routine also doesn't provide a
full path to the startup parameter, so it is unable to execute the
parameter which causes the JOB command to fail.

Since it is unnecessary to set the environment variables again,
remove the setting of the startup parameter.