### PR TITLE
Fix SCA_ERROR_DIR and JDBC destination

### DIFF
--- a/extcall_V1.2/alerts/CMakeLists.txt
+++ b/extcall_V1.2/alerts/CMakeLists.txt
@@ -27,4 +27,13 @@ install(TARGETS alertsversion DESTINATION bin)
 configure_file(alerts.xc.in alerts.xc)
 install(FILES ${CMAKE_BINARY_DIR}/extcall_V1.2/alerts/alerts.xc DESTINATION lib)
 
+# Error tables
+install(FILES
+	      stbler.err
+	      stblmsg.err
+	      merror.err
+	      queue.err
+	      mupip.err
+	DESTINATION tables)
+
 install(PROGRAMS sca_alert.sh DESTINATION bin)

--- a/gtmenv
+++ b/gtmenv
@@ -42,7 +42,9 @@ export gtm_dist GTM_DIST
 # Set up the SCA GTM variables
 SCA_GTMO=${DIR}/util/obj
 SCA_RTNS=${DIR}/util
-export SCA_GTMO SCA_RTNS 
+SCA_ERROR_DIR=${DIR}/alerts
+ALERT_SCRIPT=${DIR}/bin/sca_alert.sh
+export SCA_GTMO SCA_RTNS SCA_ERROR_DIR ALERT_SCRIPT
 
 # Set up the IBS or FMS directory variables (SCAU variables)
 SCAU_DIR=${DIR}

--- a/jdbc/CMakeLists.txt
+++ b/jdbc/CMakeLists.txt
@@ -139,4 +139,4 @@ if(usemq)
 endif()
 
 add_jar(ScJDBC ${SOURCES})
-install_jar(ScJDBC DESTINATION jdbc)
+install_jar(ScJDBC jdbc)

--- a/pipstart
+++ b/pipstart
@@ -1,8 +1,8 @@
 #!/bin/bash
 cd `dirname $0`
 rm -f *.mj[oe]
-SCA_ERROR_DIR=$PWD/extcall_V1.2/alerts ; export SCA_ERROR_DIR
-ALERT_SCRIPT=$PWD/extcall_V1.2/alerts/sca_alert.sh ; export ALERT_SCRIPT
+SCA_ERROR_DIR=$PWD/alerts ; export SCA_ERROR_DIR
+ALERT_SCRIPT=$PWD/bin/sca_alert.sh ; export ALERT_SCRIPT
 . ./gtmenv
 ./mtm/PIPMTM
 sleep 5

--- a/pipstart-docker
+++ b/pipstart-docker
@@ -4,7 +4,7 @@ trap "/home/pip/pip/pipstop" SIGTERM
 
 cd `dirname $0`
 rm -f *.mj[oe]
-SCA_ERROR_DIR=$PWD/extcall_V1.2/alerts ; export SCA_ERROR_DIR
+SCA_ERROR_DIR=$PWD/alerts ; export SCA_ERROR_DIR
 ALERT_SCRIPT=$PWD/bin/sca_alert.sh ; export ALERT_SCRIPT
 . ./gtmenv
 ./bin/pipmtm


### PR DESCRIPTION
 * The alert error tables are falling back to hard coded defaults
   due to an exported path not being defined
 * Add error tables to installed directory structure
 * Fix destination for JDBC jar